### PR TITLE
Update healthcheck command format in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - HEALTH_CHECK_TIMEOUT=10
       - HEALTH_CHECK_RETRIES=3
     healthcheck:
-      test: ["/app/healthcheck.sh"]
+      test: ["CMD-SHELL", "/app/healthcheck.sh"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
error:healthcheck.test must start either by "CMD", "CMD-SHELL" or "NONE"